### PR TITLE
Fix for invalid value of tree_id in MPTTMixin class

### DIFF
--- a/tests/test_mptt_mixin.py
+++ b/tests/test_mptt_mixin.py
@@ -55,21 +55,15 @@ def assert_nodes_ids(items, ids, pk='id'):
 
 
 @pytest.mark.django_db
-async def test_create_one_top(clear_table, create_test_model_instance, app, aiohttp_client):
-    await aiohttp_client(app)
-    await clear_table()
-    top1 = await create_test_model_instance(name="Top1")
-    await assert_mptt_valid(top1, parent_id=None, level=0, tree_id=1, lft=1, rght=2)
-
-
-@pytest.mark.django_db
-async def test_create_two_tops(clear_table, create_test_model_instance, app, aiohttp_client):
+async def test_create_several_tops(clear_table, create_test_model_instance, app, aiohttp_client):
     await aiohttp_client(app)
     await clear_table()
     top1 = await create_test_model_instance(name="Top1")
     top2 = await create_test_model_instance(name="Top2")
+    top3 = await create_test_model_instance(name="Top3")
     await assert_mptt_valid(top1, parent_id=None, level=0, tree_id=1, lft=1, rght=2)
     await assert_mptt_valid(top2, parent_id=None, level=0, tree_id=2, lft=1, rght=2)
+    await assert_mptt_valid(top3, parent_id=None, level=0, tree_id=3, lft=1, rght=2)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
In MPTTMixin.create() incorrect values of tree_id seems to be assigned when creating root nodes