### PR TITLE
Fix missing `html` argument in E-Mail template translation

### DIFF
--- a/dvhb_hybrid/mailer/amodels.py
+++ b/dvhb_hybrid/mailer/amodels.py
@@ -50,4 +50,6 @@ class EmailTemplateTranslation(Model):
         html = self.file_html
         if html:
             data['html'] = Jinja2Render(env=env, template_name=html)
+        else:
+            data['html'] = None
         return data


### PR DESCRIPTION
There was an error when passing result of `translation.as_dict()` to `dvhb_hybrid.mailer.template.EmailTemplate`.
You always need to specify `html` argument even if it's `None`.