### PR TITLE
App label must be a valid python identifier

### DIFF
--- a/dvhb_hybrid/users/apps.py
+++ b/dvhb_hybrid/users/apps.py
@@ -4,5 +4,5 @@ from django.utils.translation import ugettext_lazy as _
 
 class UsersConfig(AppConfig):
     name = 'dvhb_hybrid.users'
-    label = 'dvhb_hybrid.users'
+    label = 'dvhb_hybrid_users'
     verbose_name = _('users')


### PR DESCRIPTION
See https://docs.djangoproject.com/en/3.2/ref/applications/#django.apps.AppConfig.label